### PR TITLE
Add custom Gridstack-based admin dashboard

### DIFF
--- a/custom-dashboard-grid/assets/css/dashboard.css
+++ b/custom-dashboard-grid/assets/css/dashboard.css
@@ -1,0 +1,96 @@
+.cdg-dashboard-wrapper {
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 20px 0;
+}
+
+.grid-stack {
+    background-color: #f0f2f5;
+}
+
+.grid-stack-item {
+    transition: box-shadow 0.2s ease-in-out;
+}
+
+.grid-stack-item.ui-draggable-dragging,
+.grid-stack-item.ui-resizable-resizing {
+    z-index: 100;
+    box-shadow: 0 15px 35px rgba(0, 0, 0, 0.15);
+}
+
+.grid-stack-item-content {
+    background-color: #ffffff;
+    border-radius: 8px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+    overflow: hidden;
+}
+
+.grid-stack-item-content h2 {
+    margin: 0;
+    padding: 14px 18px;
+    background: linear-gradient(135deg, #4f46e5, #6366f1);
+    color: #ffffff;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: move;
+    user-select: none;
+}
+
+.cdg-widget-content {
+    padding: 18px;
+    flex: 1;
+    overflow: auto;
+}
+
+.cdg-widget-tresorerie .cdg-balance {
+    font-size: 20px;
+    margin-bottom: 14px;
+}
+
+.cdg-widget-tresorerie ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.cdg-widget-tresorerie li {
+    display: flex;
+    justify-content: space-between;
+    padding: 6px 0;
+}
+
+.cdg-positive {
+    color: #059669;
+    font-weight: 600;
+}
+
+.cdg-negative {
+    color: #dc2626;
+    font-weight: 600;
+}
+
+.cdg-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.cdg-table th,
+.cdg-table td {
+    padding: 10px 12px;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.cdg-table thead th {
+    text-align: left;
+    font-size: 14px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #6b7280;
+}
+
+.cdg-align-right {
+    text-align: right;
+}

--- a/custom-dashboard-grid/assets/js/dashboard.js
+++ b/custom-dashboard-grid/assets/js/dashboard.js
@@ -1,0 +1,92 @@
+(function ( $ ) {
+    'use strict';
+
+    $( function () {
+        var gridElement = $( '.grid-stack' );
+        if ( ! gridElement.length || typeof GridStack === 'undefined' ) {
+            return;
+        }
+
+        var settings = window.CustomDashboardGrid || {};
+        var grid      = GridStack.init( {
+            column: 4,
+            cellHeight: 200,
+            margin: 10,
+            float: false,
+            disableOneColumnMode: true,
+            draggable: {
+                handle: '.grid-stack-item-content h2'
+            },
+            resizable: {
+                handles: 'e, se, s, sw, w'
+            }
+        }, '.grid-stack' );
+
+        var savedLayout = Array.isArray( settings.layout ) ? settings.layout : [];
+
+        if ( savedLayout.length ) {
+            grid.batchUpdate();
+            savedLayout.forEach( function ( item ) {
+                var element = gridElement.find( '.grid-stack-item[gs-id="' + item.id + '"]' ).get( 0 );
+                if ( element && element.gridstackNode ) {
+                    grid.update( element, {
+                        x: parseInt( item.x, 10 ) || 0,
+                        y: parseInt( item.y, 10 ) || 0,
+                        w: parseInt( item.width, 10 ) || 1,
+                        h: parseInt( item.height, 10 ) || 1
+                    } );
+                }
+            } );
+            grid.commit();
+        }
+
+        var saveTimer = null;
+
+        function scheduleSave() {
+            if ( saveTimer ) {
+                clearTimeout( saveTimer );
+            }
+
+            saveTimer = setTimeout( saveLayout, 500 );
+        }
+
+        function saveLayout() {
+            if ( ! settings.ajaxUrl ) {
+                return;
+            }
+
+            var layout = [];
+
+            grid.engine.nodes.forEach( function ( node ) {
+                if ( ! node.el ) {
+                    return;
+                }
+
+                var id = node.el.getAttribute( 'gs-id' );
+                if ( ! id ) {
+                    return;
+                }
+
+                layout.push( {
+                    id: id,
+                    x: node.x,
+                    y: node.y,
+                    width: node.w,
+                    height: node.h
+                } );
+            } );
+
+            $.ajax( {
+                method: 'POST',
+                url: settings.ajaxUrl,
+                data: {
+                    action: 'save_dashboard_layout',
+                    nonce: settings.nonce,
+                    layout: JSON.stringify( layout )
+                }
+            } );
+        }
+
+        grid.on( 'change', scheduleSave );
+    } );
+})( jQuery );

--- a/custom-dashboard-grid/custom-dashboard-grid.php
+++ b/custom-dashboard-grid/custom-dashboard-grid.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Plugin Name: Custom Dashboard Grid
+ * Description: Ajoute un tableau de bord administrateur personnalisé basé sur Gridstack.
+ * Version: 1.0.0
+ * Author: Your Name
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Custom_Dashboard_Grid {
+
+    /**
+     * Initialisation du plugin.
+     */
+    public static function init() {
+        self::define_constants();
+        self::include_files();
+        add_action( 'admin_menu', array( __CLASS__, 'register_dashboard_page' ) );
+        add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+    }
+
+    /**
+     * Définit les constantes utiles.
+     */
+    private static function define_constants() {
+        if ( ! defined( 'CDG_PLUGIN_DIR' ) ) {
+            define( 'CDG_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+        }
+
+        if ( ! defined( 'CDG_PLUGIN_URL' ) ) {
+            define( 'CDG_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+        }
+    }
+
+    /**
+     * Inclut les fichiers nécessaires.
+     */
+    private static function include_files() {
+        require_once CDG_PLUGIN_DIR . 'includes/ajax-save-layout.php';
+        require_once CDG_PLUGIN_DIR . 'includes/dashboard-structure.php';
+        require_once CDG_PLUGIN_DIR . 'includes/widgets/widget-tresorerie.php';
+        require_once CDG_PLUGIN_DIR . 'includes/widgets/widget-depenses.php';
+    }
+
+    /**
+     * Ajoute la page du tableau de bord personnalisé.
+     */
+    public static function register_dashboard_page() {
+        add_menu_page(
+            __( 'Tableau de bord personnalisé', 'custom-dashboard-grid' ),
+            __( 'Tableau personnalisé', 'custom-dashboard-grid' ),
+            'manage_options',
+            'custom-dashboard-grid',
+            array( __CLASS__, 'render_dashboard_page' ),
+            'dashicons-screenoptions',
+            3
+        );
+    }
+
+    /**
+     * Affiche la page du tableau de bord.
+     */
+    public static function render_dashboard_page() {
+        $user_id       = get_current_user_id();
+        $saved_layout  = get_user_meta( $user_id, 'custom_dashboard_grid_layout', true );
+        $layout        = is_array( $saved_layout ) ? $saved_layout : array();
+
+        echo '<div class="wrap custom-dashboard-grid">';
+        echo '<h1>' . esc_html__( 'Tableau de bord personnalisé', 'custom-dashboard-grid' ) . '</h1>';
+        cdg_render_dashboard_structure( $layout );
+        echo '</div>';
+    }
+
+    /**
+     * Charge les scripts et styles pour la page du dashboard.
+     *
+     * @param string $hook Hook courant.
+     */
+    public static function enqueue_assets( $hook ) {
+        if ( 'toplevel_page_custom-dashboard-grid' !== $hook ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'gridstack-css',
+            'https://cdn.jsdelivr.net/npm/gridstack@8.4.2/dist/gridstack.min.css',
+            array(),
+            '8.4.2'
+        );
+
+        wp_enqueue_style(
+            'custom-dashboard-grid',
+            CDG_PLUGIN_URL . 'assets/css/dashboard.css',
+            array( 'gridstack-css' ),
+            '1.0.0'
+        );
+
+        wp_enqueue_script( 'jquery-ui-draggable' );
+        wp_enqueue_script( 'jquery-ui-resizable' );
+
+        wp_enqueue_script(
+            'gridstack-js',
+            'https://cdn.jsdelivr.net/npm/gridstack@8.4.2/dist/gridstack-h5.js',
+            array( 'jquery' ),
+            '8.4.2',
+            true
+        );
+
+        wp_enqueue_script(
+            'custom-dashboard-grid',
+            CDG_PLUGIN_URL . 'assets/js/dashboard.js',
+            array( 'jquery', 'gridstack-js' ),
+            '1.0.0',
+            true
+        );
+
+        $user_id      = get_current_user_id();
+        $saved_layout = get_user_meta( $user_id, 'custom_dashboard_grid_layout', true );
+
+        wp_localize_script(
+            'custom-dashboard-grid',
+            'CustomDashboardGrid',
+            array(
+                'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+                'nonce'   => wp_create_nonce( 'custom_dashboard_grid_nonce' ),
+                'layout'  => is_array( $saved_layout ) ? array_values( $saved_layout ) : array(),
+            )
+        );
+    }
+}
+
+Custom_Dashboard_Grid::init();

--- a/custom-dashboard-grid/includes/ajax-save-layout.php
+++ b/custom-dashboard-grid/includes/ajax-save-layout.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Gestion de la sauvegarde du layout via Ajax.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! function_exists( 'cdg_handle_save_dashboard_layout' ) ) {
+    /**
+     * Sauvegarde la disposition du dashboard pour l'utilisateur courant.
+     */
+    function cdg_handle_save_dashboard_layout() {
+        check_ajax_referer( 'custom_dashboard_grid_nonce', 'nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( array( 'message' => __( 'Action non autorisée.', 'custom-dashboard-grid' ) ), 403 );
+        }
+
+        $user_id = get_current_user_id();
+
+        if ( ! $user_id ) {
+            wp_send_json_error( array( 'message' => __( 'Utilisateur invalide.', 'custom-dashboard-grid' ) ), 400 );
+        }
+
+        $layout_json = isset( $_POST['layout'] ) ? wp_unslash( $_POST['layout'] ) : '';
+        $layout_data = json_decode( $layout_json, true );
+
+        if ( ! is_array( $layout_data ) ) {
+            wp_send_json_error( array( 'message' => __( 'Format de données invalide.', 'custom-dashboard-grid' ) ), 400 );
+        }
+
+        $sanitized_layout = array();
+
+        foreach ( $layout_data as $item ) {
+            if ( empty( $item['id'] ) ) {
+                continue;
+            }
+
+            $widget_id = sanitize_key( $item['id'] );
+
+            $sanitized_layout[ $widget_id ] = array(
+                'id'     => $widget_id,
+                'x'      => isset( $item['x'] ) ? intval( $item['x'] ) : 0,
+                'y'      => isset( $item['y'] ) ? intval( $item['y'] ) : 0,
+                'width'  => isset( $item['width'] ) ? max( 1, intval( $item['width'] ) ) : 1,
+                'height' => isset( $item['height'] ) ? max( 1, intval( $item['height'] ) ) : 1,
+            );
+        }
+
+        update_user_meta( $user_id, 'custom_dashboard_grid_layout', $sanitized_layout );
+
+        wp_send_json_success( array( 'layout' => array_values( $sanitized_layout ) ) );
+    }
+}
+
+add_action( 'wp_ajax_save_dashboard_layout', 'cdg_handle_save_dashboard_layout' );

--- a/custom-dashboard-grid/includes/dashboard-structure.php
+++ b/custom-dashboard-grid/includes/dashboard-structure.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Structure du tableau de bord et inclusion des widgets.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! function_exists( 'cdg_get_dashboard_widgets' ) ) {
+    /**
+     * Récupère la liste des widgets disponibles.
+     *
+     * @return array
+     */
+    function cdg_get_dashboard_widgets() {
+        return array(
+            'tresorerie' => array(
+                'title'    => __( 'Trésorerie', 'custom-dashboard-grid' ),
+                'callback' => 'cdg_render_widget_tresorerie',
+                'default'  => cdg_widget_tresorerie_default_layout(),
+            ),
+            'depenses'   => array(
+                'title'    => __( 'Dépenses', 'custom-dashboard-grid' ),
+                'callback' => 'cdg_render_widget_depenses',
+                'default'  => cdg_widget_depenses_default_layout(),
+            ),
+        );
+    }
+}
+
+if ( ! function_exists( 'cdg_render_dashboard_structure' ) ) {
+    /**
+     * Affiche la grille Gridstack et insère les widgets.
+     *
+     * @param array $saved_layout Données de layout sauvegardées.
+     */
+    function cdg_render_dashboard_structure( $saved_layout = array() ) {
+        $widgets = cdg_get_dashboard_widgets();
+        $layout  = is_array( $saved_layout ) ? $saved_layout : array();
+
+        echo '<div class="cdg-dashboard-wrapper">';
+        echo '<div class="grid-stack" data-gs-column="4" gs-column="4">';
+
+        foreach ( $widgets as $widget_id => $widget ) {
+            $settings = isset( $layout[ $widget_id ] ) ? wp_parse_args( $layout[ $widget_id ], $widget['default'] ) : $widget['default'];
+
+            $x = isset( $settings['x'] ) ? (int) $settings['x'] : 0;
+            $y = isset( $settings['y'] ) ? (int) $settings['y'] : 0;
+            $w = isset( $settings['width'] ) ? (int) $settings['width'] : 1;
+            $h = isset( $settings['height'] ) ? (int) $settings['height'] : 1;
+
+            echo '<div class="grid-stack-item"';
+            echo ' gs-id="' . esc_attr( $widget_id ) . '"';
+            echo ' gs-x="' . esc_attr( $x ) . '"';
+            echo ' gs-y="' . esc_attr( $y ) . '"';
+            echo ' gs-w="' . esc_attr( $w ) . '"';
+            echo ' gs-h="' . esc_attr( $h ) . '"';
+            echo ' data-gs-id="' . esc_attr( $widget_id ) . '"';
+            echo ' data-gs-x="' . esc_attr( $x ) . '"';
+            echo ' data-gs-y="' . esc_attr( $y ) . '"';
+            echo ' data-gs-width="' . esc_attr( $w ) . '"';
+            echo ' data-gs-height="' . esc_attr( $h ) . '"';
+            echo '>';
+
+            echo '<div class="grid-stack-item-content">';
+            echo '<h2>' . esc_html( $widget['title'] ) . '</h2>';
+
+            if ( is_callable( $widget['callback'] ) ) {
+                call_user_func( $widget['callback'] );
+            }
+
+            echo '</div>';
+            echo '</div>';
+        }
+
+        echo '</div>';
+        echo '</div>';
+    }
+}

--- a/custom-dashboard-grid/includes/widgets/widget-depenses.php
+++ b/custom-dashboard-grid/includes/widgets/widget-depenses.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Widget Dépenses.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! function_exists( 'cdg_widget_depenses_default_layout' ) ) {
+    /**
+     * Configuration par défaut du widget Dépenses.
+     *
+     * @return array
+     */
+    function cdg_widget_depenses_default_layout() {
+        return array(
+            'x'      => 2,
+            'y'      => 0,
+            'width'  => 2,
+            'height' => 1,
+        );
+    }
+}
+
+if ( ! function_exists( 'cdg_render_widget_depenses' ) ) {
+    /**
+     * Affiche le contenu du widget Dépenses.
+     */
+    function cdg_render_widget_depenses() {
+        $expenses = array(
+            array(
+                'label' => __( 'Marketing', 'custom-dashboard-grid' ),
+                'amount' => 980.50,
+            ),
+            array(
+                'label' => __( 'Frais généraux', 'custom-dashboard-grid' ),
+                'amount' => 1320.20,
+            ),
+            array(
+                'label' => __( 'Prestations externes', 'custom-dashboard-grid' ),
+                'amount' => 760.00,
+            ),
+        );
+        ?>
+        <div class="cdg-widget-content cdg-widget-depenses">
+            <table class="cdg-table">
+                <thead>
+                    <tr>
+                        <th scope="col"><?php esc_html_e( 'Catégorie', 'custom-dashboard-grid' ); ?></th>
+                        <th scope="col" class="cdg-align-right"><?php esc_html_e( 'Montant', 'custom-dashboard-grid' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ( $expenses as $expense ) : ?>
+                    <tr>
+                        <td><?php echo esc_html( $expense['label'] ); ?></td>
+                        <td class="cdg-align-right"><?php echo esc_html( number_format_i18n( $expense['amount'], 2 ) ); ?> €</td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php
+    }
+}

--- a/custom-dashboard-grid/includes/widgets/widget-tresorerie.php
+++ b/custom-dashboard-grid/includes/widgets/widget-tresorerie.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Widget Trésorerie.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! function_exists( 'cdg_widget_tresorerie_default_layout' ) ) {
+    /**
+     * Configuration par défaut du widget Trésorerie.
+     *
+     * @return array
+     */
+    function cdg_widget_tresorerie_default_layout() {
+        return array(
+            'x'      => 0,
+            'y'      => 0,
+            'width'  => 2,
+            'height' => 1,
+        );
+    }
+}
+
+if ( ! function_exists( 'cdg_render_widget_tresorerie' ) ) {
+    /**
+     * Affiche le contenu du widget Trésorerie.
+     */
+    function cdg_render_widget_tresorerie() {
+        $cash_balance   = 12500.75;
+        $incoming       = 4890.00;
+        $outgoing       = 3200.45;
+        $formatted_cash = number_format_i18n( $cash_balance, 2 );
+        $formatted_in   = number_format_i18n( $incoming, 2 );
+        $formatted_out  = number_format_i18n( $outgoing, 2 );
+        ?>
+        <div class="cdg-widget-content cdg-widget-tresorerie">
+            <p class="cdg-balance"><?php esc_html_e( 'Solde actuel', 'custom-dashboard-grid' ); ?> : <strong><?php echo esc_html( $formatted_cash ); ?> €</strong></p>
+            <ul>
+                <li><?php esc_html_e( 'Entrées prévues', 'custom-dashboard-grid' ); ?> : <span class="cdg-positive"><?php echo esc_html( $formatted_in ); ?> €</span></li>
+                <li><?php esc_html_e( 'Sorties prévues', 'custom-dashboard-grid' ); ?> : <span class="cdg-negative"><?php echo esc_html( $formatted_out ); ?> €</span></li>
+            </ul>
+        </div>
+        <?php
+    }
+}


### PR DESCRIPTION
## Summary
- add a new Custom Dashboard Grid plugin skeleton that registers an admin menu entry and loads Gridstack assets
- render a four-column Gridstack layout that includes standalone Trésorerie and Dépenses widgets
- persist widget position and sizing to user meta through an authenticated AJAX endpoint and automatic JavaScript saves

## Testing
- php -l custom-dashboard-grid/includes/dashboard-structure.php
- php -l custom-dashboard-grid/includes/widgets/widget-tresorerie.php
- php -l custom-dashboard-grid/includes/widgets/widget-depenses.php
- php -l custom-dashboard-grid/includes/ajax-save-layout.php
- php -l custom-dashboard-grid/custom-dashboard-grid.php

------
https://chatgpt.com/codex/tasks/task_b_68cbf3d75ed08322a9a24002bd221114